### PR TITLE
Avoid write advanceWidthBits when monospace.

### DIFF
--- a/lib/font/table_glyf.js
+++ b/lib/font/table_glyf.js
@@ -38,7 +38,7 @@ class Glyf {
     const f = this.font;
 
     // Store Width
-    if (f.advanceWidthBits > 0) {
+    if (f.advanceWidthBits > 0 && !f.monospaced) {
       let w = f.widthToInt(glyph.advanceWidth);
       bs.writeBits(w, f.advanceWidthBits);
     }


### PR DESCRIPTION
On https://github.com/lvgl/lv_font_conv/blob/master/lib/font/table_head.js : 84
```
if (f.monospaced) buf.writeUInt8(0, O_ADVANCE_WIDTH_BITS);
else buf.writeUInt8(f.advanceWidthBits, O_ADVANCE_WIDTH_BITS);
```
On https://github.com/lvgl/lv_font_conv/blob/master/lib/font/table_glyf.js : 40
```
// Store Width
if (f.advanceWidthBits > 0) {
  let w = f.widthToInt(glyph.advanceWidth);
  bs.writeBits(w, f.advanceWidthBits);
}
```
If the font is monospaced, 0 is written on O_ADVANCE_WIDTH_BITS, but when writing the glyph, it uses f.advanceWidthBits, without a monospace test.
When parsing I don't know how many bits to read.

I added an extra check for monospace before writing the `advanceWidth`.