### PR TITLE
verify nodejs is at least 12

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
   },
   "browserslist": [
     "last 1 Chrome version"
-  ]
+  ],
+  "engines": {
+     "node" : ">=12.0.0"
+  }
 }


### PR DESCRIPTION
first: thanks a lot for this.

This PR adds version checking for node - at least 12. (lowest test I managed to to was v12.22.5, so maybe 12 isn't good enough)

closes #61 #73  (in the package itself)
