### PR TITLE
feat: add option to set the name of the font structure when using LVGL output format

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -268,6 +268,10 @@ List of characters to copy, belongs to previously declared "--font". Examples:
     help: 'Set alternate "lvgl.h" path (for --format lvgl).'
   });
 
+  parser.add_argument('--lv-font-name', {
+    help: 'Variable name of the lvgl font structure. Defaults to the output\'s basename.'
+  });
+
   parser.add_argument('--full-info', {
     dest: 'full_info',
     action: 'store_true',

--- a/lib/writers/lvgl/lv_font.js
+++ b/lib/writers/lvgl/lv_font.js
@@ -15,8 +15,11 @@ class LvFont extends Font {
   constructor(fontData, options) {
     super(fontData, options);
 
-    const ext = path.extname(options.output);
-    this.font_name = path.basename(options.output, ext);
+    this.font_name = options.lv_font_name;
+    if (!this.font_name) {
+      const ext = path.extname(options.output);
+      this.font_name = path.basename(options.output, ext);
+    }
 
     if (options.bpp === 3 & options.no_compress) {
       throw new AppError('LittlevGL supports "--bpp 3" with compression only');


### PR DESCRIPTION
Closes #82 