### PR TITLE
web/content.html: Mention that the web converter's source code is also on GitHub

### DIFF
--- a/web/content.html
+++ b/web/content.html
@@ -4,7 +4,7 @@
 
 	    <p>The font converter is designed to be compatible with <a href="https://lvgl.io" title="Open-source Embedded GUI Library">LVGL</a> but with minor modification you can make it compatible with other graphics libraries.</p>
 
-		<p>The offline version of the converter is available <a href="https://github.com/lvgl/lv_font_conv" title="Offline font converter on GitHub">here</a></p>
+		<p>The offline version of the converter (as well as the source code for this website) is available <a href="https://github.com/lvgl/lv_font_conv" title="Offline font converter on GitHub">here</a></p>
 
 		<h3>How to use the font converter?</h3>
 		<ol>


### PR DESCRIPTION
The text as previously written seems to imply that the GitHub repo only contains the CLI version of the converter.