### PR TITLE
web: Use <script type="module"> to satisfy parcel

### DIFF
--- a/web/content.html
+++ b/web/content.html
@@ -161,6 +161,6 @@
     </ul>
   </div>
 
-<script src="./index.js" type="text/javascript"></script>
+<script src="./index.js" type="module"></script>
 
 </div>


### PR DESCRIPTION
Without this change, parcel (as run by `npm run start`) complains:

    @parcel/transformer-js: Browser scripts cannot have imports or exports. Use a <script type="module"> instead.


To be fair, I don't understand web technology well enough to judge whether this is truly a good idea.