### PR TITLE
Added version check for fallback field of the font struct

### DIFF
--- a/lib/writers/lvgl/lv_table_head.js
+++ b/lib/writers/lvgl/lv_table_head.js
@@ -94,7 +94,9 @@ lv_font_t ${f.font_name} = {
     .underline_thickness = ${f.src.underlineThickness},
 #endif
     .dsc = &font_dsc,          /*The custom font data. Will be accessed by \`get_glyph_bitmap/dsc\` */
+#if LV_VERSION_CHECK(8, 2, 0) || LVGL_VERSION_MAJOR >= 9
     .fallback = ${f.fallback},
+#endif
     .user_data = NULL,
 };
 `.trim();


### PR DESCRIPTION
The `fallback` field of the `lv_font_t` struct was added in LVGL v8.2.0, thus a version check is required to generate fonts compatibile with previous versions.