### PR TITLE
Modify the format0 length limit.

### DIFF
--- a/lib/font/cmap_build_subtables.js
+++ b/lib/font/cmap_build_subtables.js
@@ -47,7 +47,7 @@ module.exports = function cmap_split(all_codepoints) {
       let prev_dist = (j - 1 >= 0) ? min_paths[j - 1].dist : 0;
       let s;
 
-      if (all_codepoints[i] - all_codepoints[j] < 256) {
+      if (all_codepoints[i] - all_codepoints[j] < 255) {
         s = estimate_format0_size(all_codepoints[j], all_codepoints[i]);
 
         /* eslint-disable max-depth */
@@ -61,7 +61,7 @@ module.exports = function cmap_split(all_codepoints) {
         }
       }
 
-      if (all_codepoints[i] - all_codepoints[j] < 256 && all_codepoints[i] - i === all_codepoints[j] - j) {
+      if (all_codepoints[i] - all_codepoints[j] < 255 && all_codepoints[i] - i === all_codepoints[j] - j) {
         s = estimate_format0_tiny_size(all_codepoints[j], all_codepoints[i]);
 
         /* eslint-disable max-depth */


### PR DESCRIPTION
### Description

This Pull Request fixes a bug in the `lv_font_conv` tool where the `list_length` in `LV_FONT_FMT_TXT_CMAP_FORMAT0_FULL` type cmap could exceed 255, causing memory allocation issues and incorrect character mapping. The issue was identified when using the `symbols` parameter, which led to the generation of a `glyph_id_ofs_list` with 256 elements.

### Changes Made

- Modified the `cmap_split` function to ensure that the character range length does not exceed 255.

### Related Issue

- This Pull Request addresses issue #118. Please refer to the issue for more details: https://github.com/lvgl/lv_font_conv/issues/118

### Testing

- Tested with various character ranges to ensure `list_length` does not exceed 255.
- Verified that the generated font files have correct character mappings.
