### PR TITLE
Fix generated headers

### DIFF
--- a/lib/writers/lvgl/lv_font.js
+++ b/lib/writers/lvgl/lv_font.js
@@ -77,10 +77,18 @@ class LvFont extends Font {
  * Opts: ${this.opts.opts_string}
  ******************************************************************************/
 
+#ifdef __has_include
+    #if __has_include("lvgl.h")
+        #ifndef LV_LVGL_H_INCLUDE_SIMPLE
+            #define LV_LVGL_H_INCLUDE_SIMPLE
+        #endif
+    #endif
+#endif
+
 #ifdef LV_LVGL_H_INCLUDE_SIMPLE
-#include "lvgl.h"
+    #include "lvgl.h"
 #else
-#include "${this.opts.lv_include || 'lvgl/lvgl.h'}"
+    #include "${this.opts.lv_include || 'lvgl/lvgl.h'}"
 #endif
 
 #ifndef ${guard_name}


### PR DESCRIPTION
The currently generated C file for custom fonts is missing a block at the top to set `LV_LVGL_H_INCLUDE_SIMPLE` conditionally as is done in the current image converter. This will fail to compile depending on how your include paths are set up as it does for me.

Fixes lvgl/lv_font_conv#116