### PR TITLE
See issue https://github.com/lvgl/lv_font_conv/issues/120

### DIFF
--- a/lib/writers/lvgl/lv_table_glyf.js
+++ b/lib/writers/lvgl/lv_table_glyf.js
@@ -41,12 +41,13 @@ class LvGlyf extends Glyf {
     f.src.glyphs.forEach(g => {
       const id = f.glyph_id[g.code];
       const bin = this.lv_bitmap(g);
+      const dup = this.lv_data.find(d => d && d.bin.equals(bin));
       this.lv_data[id] = {
-        bin,
-        offset,
+        bin: dup ? Buffer.from([]) : bin,
+        offset: dup ? dup.offset : offset,
         glyph: g
       };
-      offset += bin.length;
+      offset += dup ? 0 : bin.length;
     });
   }
 
@@ -55,17 +56,14 @@ class LvGlyf extends Glyf {
 
     let result = [];
     this.lv_data.forEach((d, idx) => {
-      if (idx === 0) return;
+      if (idx === 0 || d.bin.length == 0) return;
       const code_hex = d.glyph.code.toString(16).toUpperCase();
       const code_str = JSON.stringify(String.fromCodePoint(d.glyph.code));
 
       let txt = `    /* U+${code_hex.padStart(4, '0')} ${code_str} */
-${u.long_dump(d.bin, { hex: true })}`;
+${u.long_dump(d.bin, { hex: true })},`;
 
-      if (idx < this.lv_data.length - 1) {
-        // skip comma for zero data
-        txt += d.bin.length ? ',\n\n' : '\n';
-      }
+      result.length > 0 && result.push('\n\n');
 
       result.push(txt);
     });


### PR DESCRIPTION
In LVGL export format, avoid storing duplicate bitmap data for identical glyphs. Instead, reference existing bitmap data.