### PR TITLE
feat(glyph): add --byte-align option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Common:
   grayscale icons. Since gray tones are emulated via transparency, result
   will be good on contrast background only.
 - `--lv-include` - only with `--format lvgl`, set alternate path for `lvgl.h`.
+- `--no-compress` - disable built-in RLE compression.
+- `--no-prefilter` - disable bitmap lines filter (XOR), used to improve
+  compression ratio.
+- `--byte-align` - pad the line ends of the bitmaps to a whole byte (requires `--no-compress` and `--bpp != 3`)
+- `--no-kerning` - drop kerning info to reduce size (not recommended).
 
 Per font:
 
@@ -79,11 +84,6 @@ Per font:
 - `--autohint-strong` - use more strong autohinting (will break kerning).
 
 Additional debug options:
-
-- `--no-compress` - disable built-in RLE compression.
-- `--no-prefilter` - disable bitmap lines filter (XOR), used to improve
-  compression ratio.
-- `--no-kerning` - drop kerning info to reduce size (not recommended).
 - `--full-info` - don't shorten 'font_info.json' (include pixels data).
 
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -263,6 +263,13 @@ List of characters to copy, belongs to previously declared "--font". Examples:
     help: 'Drop kerning info to reduce size (not recommended).'
   });
 
+  parser.add_argument('--byte-align', {
+    dest: 'byte_align',
+    action: 'store_true',
+    default: false,
+    help: 'Pad bitmap line endings to whole bytes.'
+  });
+
   parser.add_argument('--lv-include', {
     metavar: '<path>',
     help: 'Set alternate "lvgl.h" path (for --format lvgl).'
@@ -299,6 +306,16 @@ List of characters to copy, belongs to previously declared "--font". Examples:
       font.source_bin = fs.readFileSync(font.source_path);
     } catch (err) {
       parser.error(`Cannot read file "${font.source_path}": ${err.message}`);
+    }
+  }
+
+  if (args.byte_align) {
+    if (args.no_compress === false) {
+      parser.error('--byte_align requires --no-compress');
+    }
+
+    if (args.bpp === 3) {
+      parser.error('--byte_align requires --bpp 1, 2, 4, or 8');
     }
   }
 

--- a/lib/font/table_glyf.js
+++ b/lib/font/table_glyf.js
@@ -60,17 +60,29 @@ class Glyf {
   }
 
   storePixels(bitStream, pixels) {
-    if (this.getCompressionCode() === 0) this.storePixelsRaw(bitStream, pixels);
+    if (this.getCompressionCode() === 0 || this.getCompressionCode() === 3) this.storePixelsRaw(bitStream, pixels);
     else this.storePixelsCompressed(bitStream, pixels);
   }
 
   storePixelsRaw(bitStream, pixels) {
+    if (pixels.length === 0) return;
+
     const bpp = this.font.opts.bpp;
+    let pad = 0;
+    if (this.font.opts.byte_align) {
+      const pxPerByte = 8 / bpp;
+      pad = pxPerByte - (pixels[0].length % pxPerByte);
+    }
 
     for (let y = 0; y < pixels.length; y++) {
       const line = pixels[y];
       for (let x = 0; x < line.length; x++) {
         bitStream.writeBits(line[x], bpp);
+      }
+      if (pad) {
+        for (let x = 0; x < pad; x++) {
+          bitStream.writeBits(0, bpp);
+        }
       }
     }
   }
@@ -135,9 +147,9 @@ class Glyf {
   }
 
   getCompressionCode() {
+    if (this.font.opts.byte_align) return 3;
     if (this.font.opts.no_compress) return 0;
     if (this.font.opts.bpp === 1) return 0;
-
     if (this.font.opts.no_prefilter) return 2;
     return 1;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lv_font_conv",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lv_font_conv",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "bundleDependencies": [
         "argparse",
         "bit-buffer",


### PR DESCRIPTION
Adding a `--byte-align` option to pad the bitmap lines to a whole byte. It's required for GPUs acceleration. See https://github.com/lvgl/lvgl/issues/7026



