### PR TITLE
feat(glyph) add stride align and glyph start address align options

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -270,6 +270,20 @@ List of characters to copy, belongs to previously declared "--font". Examples:
     help: 'Pad bitmap line endings to whole bytes.'
   });
 
+  parser.add_argument('--stride', {
+    choices: [ 4, 8, 16, 32, 64 ],
+    type: positive_int,
+    default: 1,
+    help: 'Align each glyph\'s stride to the specfied number of bytes.'
+  });
+
+  parser.add_argument('--align', {
+    choices: [ 4, 8, 16, 32, 64 ],
+    type: positive_int,
+    default: 1,
+    help: 'Align each glyph address to the specified number of bytes.'
+  });
+
   parser.add_argument('--lv-include', {
     metavar: '<path>',
     help: 'Set alternate "lvgl.h" path (for --format lvgl).'

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -278,7 +278,7 @@ List of characters to copy, belongs to previously declared "--font". Examples:
   });
 
   parser.add_argument('--align', {
-    choices: [ 4, 8, 16, 32, 64 ],
+    choices: [ 1, 4, 8, 16, 32, 64 ],
     type: positive_int,
     default: 1,
     help: 'Align each glyph address to the specified number of bytes.'

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -271,7 +271,7 @@ List of characters to copy, belongs to previously declared "--font". Examples:
   });
 
   parser.add_argument('--stride', {
-    choices: [ 4, 8, 16, 32, 64 ],
+    choices: [ 0, 1, 4, 8, 16, 32, 64 ],
     type: positive_int,
     default: 1,
     help: 'Align each glyph\'s stride to the specfied number of bytes.'

--- a/lib/font/table_glyf.js
+++ b/lib/font/table_glyf.js
@@ -31,7 +31,14 @@ class Glyf {
   // Returns "binary stream" (Buffer) of compiled glyph data
   compileGlyph(glyph) {
     // Allocate memory, enough for eny storage formats
-    const buf = Buffer.alloc(100 + glyph.bbox.width * glyph.bbox.height * 4);
+    let buf;
+
+    if (this.font.opts.align !== 1 || this.font.opts.stride !== 1) {
+      buf = Buffer.alloc(100 + glyph.bbox.width * glyph.bbox.height * 4 * 4);
+    } else {
+      buf = Buffer.alloc(100 + glyph.bbox.width * glyph.bbox.height * 4);
+    }
+
     const bs = new BitStream(buf);
     bs.bigEndian = true;
     const f = this.font;
@@ -53,7 +60,14 @@ class Glyf {
     this.storePixels(bs, pixels);
 
     // Shrink size
-    const result = Buffer.alloc(bs.byteIndex);
+    let result;
+
+    if (this.font.opts.align && this.font.opts.align !== 1) {
+      result = Buffer.alloc(Math.ceil(bs.byteIndex / this.font.opts.align) * this.font.opts.align);
+    } else {
+      result = Buffer.alloc(bs.byteIndex);
+    }
+
     buf.copy(result, 0, 0, bs.byteIndex);
 
     return result;
@@ -76,12 +90,21 @@ class Glyf {
 
     for (let y = 0; y < pixels.length; y++) {
       const line = pixels[y];
-      for (let x = 0; x < line.length; x++) {
-        bitStream.writeBits(line[x], bpp);
-      }
-      if (pad) {
-        for (let x = 0; x < pad; x++) {
-          bitStream.writeBits(0, bpp);
+      if (this.font.opts.stride && this.font.opts.stride !== 1) {
+        let stride = this.font.opts.stride;
+        const alignedLine = Buffer.alloc(Math.ceil(line.length / stride) * stride);
+        alignedLine.fill(Buffer.from(line), 0, line.length);
+        for (let x = 0; x < alignedLine.length; x++) {
+          bitStream.writeBits(alignedLine[x], bpp);
+        }
+      } else {
+        for (let x = 0; x < line.length; x++) {
+          bitStream.writeBits(line[x], bpp);
+        }
+        if (pad) {
+          for (let x = 0; x < pad; x++) {
+            bitStream.writeBits(0, bpp);
+          }
         }
       }
     }

--- a/lib/font/table_glyf.js
+++ b/lib/font/table_glyf.js
@@ -78,6 +78,13 @@ class Glyf {
     else this.storePixelsCompressed(bitStream, pixels);
   }
 
+  addPadding(bitStream, pad) {
+    const bpp = this.font.opts.bpp;
+    for (let x = 0; x < pad; x++) {
+      bitStream.writeBits(0, bpp);
+    }
+  }
+
   storePixelsRaw(bitStream, pixels) {
     if (pixels.length === 0) return;
 
@@ -102,9 +109,7 @@ class Glyf {
           bitStream.writeBits(line[x], bpp);
         }
         if (pad) {
-          for (let x = 0; x < pad; x++) {
-            bitStream.writeBits(0, bpp);
-          }
+          this.addPadding(bitStream, pad);
         }
       }
     }

--- a/lib/writers/lvgl/lv_font.js
+++ b/lib/writers/lvgl/lv_font.js
@@ -41,6 +41,16 @@ class LvFont extends Font {
     this.kern = new Kern(this);
   }
 
+  stride_guard() {
+    if (this.opts.stride !== 1) {
+      return `#if !LV_VERSION_CHECK(9, 3, 0)
+#error "At least LVGL v9.3 is required to use the stride attribute of the fonts"
+#endif`;
+    }
+
+    return '';
+  }
+
   large_format_guard() {
     let guard_required = false;
     let glyphs_bin_size = 0;
@@ -91,6 +101,8 @@ class LvFont extends Font {
     #include "${this.opts.lv_include || 'lvgl/lvgl.h'}"
 #endif
 
+${this.stride_guard()}
+
 #ifndef ${guard_name}
 #define ${guard_name} 1
 #endif
@@ -108,7 +120,6 @@ ${this.head.toLVGL()}
 ${this.large_format_guard()}
 
 #endif /*#if ${guard_name}*/
-
 `;
   }
 }

--- a/lib/writers/lvgl/lv_table_glyf.js
+++ b/lib/writers/lvgl/lv_table_glyf.js
@@ -15,7 +15,14 @@ class LvGlyf extends Glyf {
   }
 
   lv_bitmap(glyph) {
-    const buf = Buffer.alloc(100 + glyph.bbox.width * glyph.bbox.height * 4);
+    let buf;
+
+    if (this.font.opts.align !== 1 || this.font.opts.stride !== 1) {
+      buf = Buffer.alloc(100 + glyph.bbox.width * glyph.bbox.height * 4 * 4);
+    } else {
+      buf = Buffer.alloc(100 + glyph.bbox.width * glyph.bbox.height * 4);
+    }
+
     const bs = new BitStream(buf);
     bs.bigEndian = true;
 
@@ -23,7 +30,13 @@ class LvGlyf extends Glyf {
 
     this.font.glyf.storePixels(bs, pixels);
 
-    const glyph_bitmap = Buffer.alloc(bs.byteIndex);
+    let glyph_bitmap;
+    if (this.font.opts.align !== 1) {
+      glyph_bitmap = Buffer.alloc(Math.ceil(bs.byteIndex / this.font.opts.align) * this.font.opts.align);
+    } else {
+      glyph_bitmap = Buffer.alloc(bs.byteIndex);
+    }
+
     buf.copy(glyph_bitmap, 0, 0, bs.byteIndex);
 
     return glyph_bitmap;
@@ -101,7 +114,7 @@ ${u.long_dump(d.bin, { hex: true })}`;
  *----------------*/
 
 /*Store the image of the glyphs*/
-static LV_ATTRIBUTE_LARGE_CONST const uint8_t glyph_bitmap[] = {
+static ${this.font.opts.align !== 1 ? 'LV_ATTRIBUTE_MEM_ALIGN ' : ''}LV_ATTRIBUTE_LARGE_CONST const uint8_t glyph_bitmap[] = {
 ${this.to_lv_bitmaps()}
 };
 

--- a/lib/writers/lvgl/lv_table_head.js
+++ b/lib/writers/lvgl/lv_table_head.js
@@ -35,6 +35,20 @@ class LvHead extends Head {
     };
   }
 
+  get_stride_align() {
+    if (this.font.opts.stride !== 1) {
+      return `    .stride = ${this.font.opts.stride}`;
+    }
+    return '';
+  }
+
+  get_static_bitmap() {
+    if (this.font.opts.stride !== 1 && this.font.opts.align !== 1) {
+      return '    .static_bitmap = 1,';
+    }
+    return '    .static_bitmap = 0,';
+  }
+
   toLVGL() {
     const f = this.font;
     const kern = this.kern_ref();
@@ -68,6 +82,7 @@ static lv_font_fmt_txt_dsc_t font_dsc = {
 #if LVGL_VERSION_MAJOR == 8
     .cache = &cache
 #endif
+${this.get_stride_align()}
 };
 
 ${f.fallback_declaration}
@@ -93,6 +108,7 @@ lv_font_t ${f.font_name} = {
     .underline_position = ${f.src.underlinePosition},
     .underline_thickness = ${f.src.underlineThickness},
 #endif
+${this.get_static_bitmap()}
     .dsc = &font_dsc,          /*The custom font data. Will be accessed by \`get_glyph_bitmap/dsc\` */
 #if LV_VERSION_CHECK(8, 2, 0) || LVGL_VERSION_MAJOR >= 9
     .fallback = ${f.fallback},


### PR DESCRIPTION
In order to get better performance on the VGLite implementation, I've added the "--vglite-align" option to generate the glyphs aligned to stride and with the start address of each glyph aligned. In this way, the address of each glyph can be used to be drawn by the GPU.

For the moment it works with bpp = 8, in A8 format.

@kisvegabor can you give an advice on how to make it generate the same glyphs, but in A4 format while keeping the alignments.