### PR TITLE
fix(lvgl_writer): always set .static_bitmap = 1

### DIFF
--- a/lib/writers/lvgl/lv_table_head.js
+++ b/lib/writers/lvgl/lv_table_head.js
@@ -42,13 +42,6 @@ class LvHead extends Head {
     return '';
   }
 
-  get_static_bitmap() {
-    if (this.font.opts.stride !== 1 && this.font.opts.align !== 1) {
-      return '    .static_bitmap = 1,';
-    }
-    return '    .static_bitmap = 0,';
-  }
-
   toLVGL() {
     const f = this.font;
     const kern = this.kern_ref();
@@ -108,7 +101,11 @@ lv_font_t ${f.font_name} = {
     .underline_position = ${f.src.underlinePosition},
     .underline_thickness = ${f.src.underlineThickness},
 #endif
-${this.get_static_bitmap()}
+
+#if LV_VERSION_CHECK(9, 3, 0)
+    .static_bitmap = 1,        /*Bitmaps are stored as const so they are always static */
+#endif
+
     .dsc = &font_dsc,          /*The custom font data. Will be accessed by \`get_glyph_bitmap/dsc\` */
 #if LV_VERSION_CHECK(8, 2, 0) || LVGL_VERSION_MAJOR >= 9
     .fallback = ${f.fallback},


### PR DESCRIPTION
Bitmaps are stored as const so they are always static. 

For GPU compatibility check the stride of the glyph and bitmap alignment. 

cc @cosmindanielradu19 

@richardgazdik please update the online font converter again. 

