### PR TITLE
fix: handle stride correctly for all bpp and deprecate byte-align

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -273,7 +273,7 @@ List of characters to copy, belongs to previously declared "--font". Examples:
   parser.add_argument('--stride', {
     choices: [ 0, 1, 4, 8, 16, 32, 64 ],
     type: 'int',
-    default: 1,
+    default: 0,
     help: 'Align each glyph\'s stride to the specfied number of bytes.'
   });
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -272,13 +272,13 @@ List of characters to copy, belongs to previously declared "--font". Examples:
 
   parser.add_argument('--stride', {
     choices: [ 0, 1, 4, 8, 16, 32, 64 ],
-    type: positive_int,
+    type: 'int',
     default: 1,
     help: 'Align each glyph\'s stride to the specfied number of bytes.'
   });
 
   parser.add_argument('--align', {
-    choices: [ 1, 4, 8, 16, 32, 64 ],
+    choices: [ 1, 4, 8, 16, 32, 64, 128, 256, 512, 1024 ],
     type: positive_int,
     default: 1,
     help: 'Align each glyph address to the specified number of bytes.'
@@ -324,12 +324,16 @@ List of characters to copy, belongs to previously declared "--font". Examples:
   }
 
   if (args.byte_align) {
+    parser.error('--byte-align is deprecated, use --stride 1 instead');
+  }
+
+  if (args.stride > 0) {
     if (args.no_compress === false) {
-      parser.error('--byte_align requires --no-compress');
+      parser.error('--stride requires --no-compress');
     }
 
     if (args.bpp === 3) {
-      parser.error('--byte_align requires --bpp 1, 2, 4, or 8');
+      parser.error('--stride requires --bpp 1, 2, 4, or 8');
     }
   }
 

--- a/lib/font/table_glyf.js
+++ b/lib/font/table_glyf.js
@@ -44,8 +44,9 @@ class Glyf {
     let buf;
 
 
-    const bufSize = (100 + this.widthToStride(glyph.bbox.width) * glyph.bbox.height) *
+    let bufSize = (100 + this.widthToStride(glyph.bbox.width) * glyph.bbox.height) *
                      this.font.opts.bpp + this.font.opts.align;
+    if (isNaN(bufSize)) bufSize = 256 * 1024; // Fallback for empty glyphs
     buf = Buffer.alloc(bufSize);
 
     const bs = new BitStream(buf);

--- a/lib/font/table_glyf.js
+++ b/lib/font/table_glyf.js
@@ -44,7 +44,7 @@ class Glyf {
     let buf;
 
 
-    let bufSize = (100 + this.widthToStride(glyph.bbox.width) * glyph.bbox.height) *
+    let bufSize = 100 + (this.widthToStride(glyph.bbox.width) * glyph.bbox.height) *
                      this.font.opts.bpp + this.font.opts.align;
     if (isNaN(bufSize)) bufSize = 256 * 1024; // Fallback for empty glyphs
     buf = Buffer.alloc(bufSize);

--- a/lib/font/table_glyf.js
+++ b/lib/font/table_glyf.js
@@ -44,9 +44,18 @@ class Glyf {
     let buf;
 
 
-    let bufSize = 100 + (this.widthToStride(glyph.bbox.width) * glyph.bbox.height) *
-                     this.font.opts.bpp + this.font.opts.align;
-    if (isNaN(bufSize)) bufSize = 256 * 1024; // Fallback for empty glyphs
+    // Check for invalid glyph.bbox dimensions to avoid invalid buffer allocation
+    let bufSize;
+    if (
+      glyph.bbox &&
+      Number.isFinite(glyph.bbox.width) &&
+      Number.isFinite(glyph.bbox.height)
+    ) {
+      bufSize = 100 + (this.widthToStride(glyph.bbox.width) * glyph.bbox.height) *
+        this.font.opts.bpp + this.font.opts.align;
+    } else {
+      bufSize = 256 * 1024; // Fallback for empty or invalid glyphs
+    }
     buf = Buffer.alloc(bufSize);
 
     const bs = new BitStream(buf);

--- a/lib/font/table_glyf.js
+++ b/lib/font/table_glyf.js
@@ -45,7 +45,7 @@ class Glyf {
 
 
     // Check for invalid glyph.bbox dimensions to avoid invalid buffer allocation
-    let bufSize;
+    let bufSize = NaN;
     if (
       glyph.bbox &&
       Number.isFinite(glyph.bbox.width) &&
@@ -53,9 +53,13 @@ class Glyf {
     ) {
       bufSize = 100 + (this.widthToStride(glyph.bbox.width) * glyph.bbox.height) *
         this.font.opts.bpp + this.font.opts.align;
-    } else {
+    }
+
+    if (!Number.isFinite(bufSize) || bufSize <= 0) {
       bufSize = 256 * 1024; // Fallback for empty or invalid glyphs
     }
+    console.log('bufSize:', bufSize);
+
     buf = Buffer.alloc(bufSize);
 
     const bs = new BitStream(buf);

--- a/lib/font/table_glyf.js
+++ b/lib/font/table_glyf.js
@@ -28,16 +28,25 @@ class Glyf {
     return pixels.map(line => line.map(p => (p >>> (8 - bpp))));
   }
 
+  widthToStride(width) {
+    const stride = this.font.opts.stride;
+    if (stride > 0) {
+      const byte_count = Math.ceil((width * this.font.opts.bpp) / 8);
+      const final_length =  Math.ceil(byte_count / stride) * stride;
+      return final_length;
+    }
+    return Math.ceil((width * this.font.opts.bpp) / 8);
+  }
+
   // Returns "binary stream" (Buffer) of compiled glyph data
   compileGlyph(glyph) {
-    // Allocate memory, enough for eny storage formats
+    // Allocate memory, enough for every storage formats
     let buf;
 
-    if (this.font.opts.align !== 1 || this.font.opts.stride !== 1) {
-      buf = Buffer.alloc(100 + glyph.bbox.width * glyph.bbox.height * 4 * 4);
-    } else {
-      buf = Buffer.alloc(100 + glyph.bbox.width * glyph.bbox.height * 4);
-    }
+
+    const bufSize = (100 + this.widthToStride(glyph.bbox.width) * glyph.bbox.height) *
+                     this.font.opts.bpp + this.font.opts.align;
+    buf = Buffer.alloc(bufSize);
 
     const bs = new BitStream(buf);
     bs.bigEndian = true;
@@ -62,7 +71,7 @@ class Glyf {
     // Shrink size
     let result;
 
-    if (this.font.opts.align && this.font.opts.align !== 1) {
+    if (this.font.opts.align !== 1) {
       result = Buffer.alloc(Math.ceil(bs.byteIndex / this.font.opts.align) * this.font.opts.align);
     } else {
       result = Buffer.alloc(bs.byteIndex);
@@ -89,28 +98,20 @@ class Glyf {
     if (pixels.length === 0) return;
 
     const bpp = this.font.opts.bpp;
-    let pad = 0;
-    if (this.font.opts.byte_align) {
-      const pxPerByte = 8 / bpp;
-      pad = pxPerByte - (pixels[0].length % pxPerByte);
+    let bit_pad_line = 0;
+    if (this.font.opts.stride > 0) {
+      const bit_count = pixels[0].length * bpp;
+      const aligned_bit_count = this.widthToStride(pixels[0].length) * 8;
+      bit_pad_line = aligned_bit_count - bit_count;
     }
 
     for (let y = 0; y < pixels.length; y++) {
       const line = pixels[y];
-      if (this.font.opts.stride && this.font.opts.stride !== 1) {
-        let stride = this.font.opts.stride;
-        const alignedLine = Buffer.alloc(Math.ceil(line.length / stride) * stride);
-        alignedLine.fill(Buffer.from(line), 0, line.length);
-        for (let x = 0; x < alignedLine.length; x++) {
-          bitStream.writeBits(alignedLine[x], bpp);
-        }
-      } else {
-        for (let x = 0; x < line.length; x++) {
-          bitStream.writeBits(line[x], bpp);
-        }
-        if (pad) {
-          this.addPadding(bitStream, pad);
-        }
+      for (let x = 0; x < line.length; x++) {
+        bitStream.writeBits(line[x], bpp);
+      }
+      if (bit_pad_line) {
+        this.addPadding(bitStream, bit_pad_line / bpp);
       }
     }
   }
@@ -175,7 +176,6 @@ class Glyf {
   }
 
   getCompressionCode() {
-    if (this.font.opts.byte_align) return 3;
     if (this.font.opts.no_compress) return 0;
     if (this.font.opts.bpp === 1) return 0;
     if (this.font.opts.no_prefilter) return 2;

--- a/lib/font/table_glyf.js
+++ b/lib/font/table_glyf.js
@@ -41,26 +41,11 @@ class Glyf {
   // Returns "binary stream" (Buffer) of compiled glyph data
   compileGlyph(glyph) {
     // Allocate memory, enough for every storage formats
-    let buf;
+    let bufSize = 100 + (this.widthToStride(glyph.bbox.width) * glyph.bbox.height) *
+                  this.font.opts.bpp + this.font.opts.align;
 
-
-    // Check for invalid glyph.bbox dimensions to avoid invalid buffer allocation
-    let bufSize = NaN;
-    if (
-      glyph.bbox &&
-      Number.isFinite(glyph.bbox.width) &&
-      Number.isFinite(glyph.bbox.height)
-    ) {
-      bufSize = 100 + (this.widthToStride(glyph.bbox.width) * glyph.bbox.height) *
-        this.font.opts.bpp + this.font.opts.align;
-    }
-
-    if (!Number.isFinite(bufSize) || bufSize <= 0) {
-      bufSize = 256 * 1024; // Fallback for empty or invalid glyphs
-    }
-    console.log('bufSize:', bufSize);
-
-    buf = Buffer.alloc(bufSize);
+    if (isNaN(bufSize) || bufSize <= 0) bufSize = 128 * 1024; // Fallback for empty glyphs
+    let buf  = Buffer.alloc(bufSize);
 
     const bs = new BitStream(buf);
     bs.bigEndian = true;
@@ -85,7 +70,7 @@ class Glyf {
     // Shrink size
     let result;
 
-    if (this.font.opts.align !== 1) {
+    if (this.font.opts.align && this.font.opts.align !== 1) {
       result = Buffer.alloc(Math.ceil(bs.byteIndex / this.font.opts.align) * this.font.opts.align);
     } else {
       result = Buffer.alloc(bs.byteIndex);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -113,7 +113,7 @@ module.exports.long_dump = function long_dump(arr, options = {}) {
   let indent = ' '.repeat(opts.indent);
 
   return chunk(Array.from(arr), opts.col)
-    .map(l => l.map(v => (opts.hex ? `0x${v.toString(16)}` : v.toString())))
+    .map(l => l.map(v => (opts.hex ? `0x${v.toString(16).padStart(2, '0')}` : v.toString())))
     .map(l => `${indent}${l.join(', ')}`)
     .join(',\n');
 };

--- a/lib/writers/lvgl/lv_font.js
+++ b/lib/writers/lvgl/lv_font.js
@@ -42,7 +42,7 @@ class LvFont extends Font {
   }
 
   stride_guard() {
-    if (this.opts.stride !== 1) {
+    if (this.opts.stride > 0) {
       return `#if !LV_VERSION_CHECK(9, 3, 0)
 #error "At least LVGL v9.3 is required to use the stride attribute of the fonts"
 #endif`;

--- a/lib/writers/lvgl/lv_table_glyf.js
+++ b/lib/writers/lvgl/lv_table_glyf.js
@@ -17,11 +17,10 @@ class LvGlyf extends Glyf {
   lv_bitmap(glyph) {
     let buf;
 
-    if (this.font.opts.align !== 1 || this.font.opts.stride !== 1) {
-      buf = Buffer.alloc(100 + glyph.bbox.width * glyph.bbox.height * 4 * 4);
-    } else {
-      buf = Buffer.alloc(100 + glyph.bbox.width * glyph.bbox.height * 4);
-    }
+    const bufSize = (100 + this.widthToStride(glyph.bbox.width) * glyph.bbox.height) *
+                     this.font.opts.bpp + this.font.opts.align;
+    buf = Buffer.alloc(bufSize);
+
 
     const bs = new BitStream(buf);
     bs.bigEndian = true;
@@ -72,8 +71,11 @@ class LvGlyf extends Glyf {
       const code_hex = d.glyph.code.toString(16).toUpperCase();
       const code_str = JSON.stringify(String.fromCodePoint(d.glyph.code));
 
+      let cols = 8;
+
+      if (this.font.opts.stride > 0) cols = this.widthToStride(d.glyph.bbox.width);
       let txt = `    /* U+${code_hex.padStart(4, '0')} ${code_str} */
-${u.long_dump(d.bin, { hex: true })}`;
+${u.long_dump(d.bin, { hex: true, col: cols })}`;
 
       if (idx < this.lv_data.length - 1) {
         // skip comma for zero data

--- a/lib/writers/lvgl/lv_table_glyf.js
+++ b/lib/writers/lvgl/lv_table_glyf.js
@@ -17,7 +17,7 @@ class LvGlyf extends Glyf {
   lv_bitmap(glyph) {
     let buf;
 
-    const bufSize = (100 + this.widthToStride(glyph.bbox.width) * glyph.bbox.height) *
+    const bufSize = 100 + (this.widthToStride(glyph.bbox.width) * glyph.bbox.height) *
                      this.font.opts.bpp + this.font.opts.align;
     buf = Buffer.alloc(bufSize);
 

--- a/lib/writers/lvgl/lv_table_head.js
+++ b/lib/writers/lvgl/lv_table_head.js
@@ -36,7 +36,7 @@ class LvHead extends Head {
   }
 
   get_stride_align() {
-    if (this.font.opts.stride !== 1) {
+    if (this.font.opts.stride > 0) {
       return `    .stride = ${this.font.opts.stride}`;
     }
     return '';
@@ -47,6 +47,8 @@ class LvHead extends Head {
     const kern = this.kern_ref();
     const subpixels = (f.subpixels_mode === 0) ? 'LV_FONT_SUBPX_NONE' :
       (f.subpixels_mode === 1) ? 'LV_FONT_SUBPX_HOR' : 'LV_FONT_SUBPX_VER';
+
+    const staticBitmap = f.glyf.getCompressionCode() === 0 ? '1' : '0';
 
     return `
 /*--------------------
@@ -103,7 +105,7 @@ lv_font_t ${f.font_name} = {
 #endif
 
 #if LV_VERSION_CHECK(9, 3, 0)
-    .static_bitmap = 1,        /*Bitmaps are stored as const so they are always static */
+    .static_bitmap = ${staticBitmap},    /*Bitmaps are stored as const so they are always static if not compressed */
 #endif
 
     .dsc = &font_dsc,          /*The custom font data. Will be accessed by \`get_glyph_bitmap/dsc\` */


### PR DESCRIPTION
Also needs https://github.com/lvgl/lvgl/pull/8887
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes stride alignment across all bpp and replaces the old byte-align behavior. Deprecates --byte-align in favor of --stride and adjusts CLI validation and LVGL output to match.

- **Bug Fixes**
  - Correct per-line padding using stride for bpp 1, 2, 4, 8; removed byte-align path.
  - Centralized widthToStride logic and sized buffers accordingly to avoid misalignment.
  - LVGL output: add stride guard for v9.3+, dump rows sized to stride, and set static_bitmap only when uncompressed.
  - CLI: deprecate --byte-align (errors with guidance), allow --stride {0,1,4..64}, require --no-compress with stride, block bpp=3 with stride, and expand --align up to 1024.
  - Hex dumps now zero-pad bytes (0x0a).

- **Migration**
  - Replace --byte-align with --stride 1.
  - When using stride (>0): pass --no-compress and use bpp 1, 2, 4, or 8; LVGL v9.3+ is required.
  - To disable stride alignment, use --stride 0.

<!-- End of auto-generated description by cubic. -->

