### PR TITLE
fix(lvgl): fix designator order for .static_bitmap

### DIFF
--- a/lib/writers/lvgl/lv_table_head.js
+++ b/lib/writers/lvgl/lv_table_head.js
@@ -99,13 +99,14 @@ lv_font_t ${f.font_name} = {
 #if !(LVGL_VERSION_MAJOR == 6 && LVGL_VERSION_MINOR == 0)
     .subpx = ${subpixels},
 #endif
-#if LV_VERSION_CHECK(7, 4, 0) || LVGL_VERSION_MAJOR >= 8
-    .underline_position = ${f.src.underlinePosition},
-    .underline_thickness = ${f.src.underlineThickness},
-#endif
 
 #if LV_VERSION_CHECK(9, 3, 0)
     .static_bitmap = ${staticBitmap},    /*Bitmaps are stored as const so they are always static if not compressed */
+#endif
+
+#if LV_VERSION_CHECK(7, 4, 0) || LVGL_VERSION_MAJOR >= 8
+    .underline_position = ${f.src.underlinePosition},
+    .underline_thickness = ${f.src.underlineThickness},
 #endif
 
     .dsc = &font_dsc,          /*The custom font data. Will be accessed by \`get_glyph_bitmap/dsc\` */


### PR DESCRIPTION
Fixes #142
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the LVGL font initializer field order by moving underline_position and underline_thickness after static_bitmap to match LVGL 9.3+ struct layout and prevent build errors. Ensures generated lv_font_t structs compile cleanly across supported versions.

<!-- End of auto-generated description by cubic. -->

