### PR TITLE
feat(glyph): add --pixel-order option for LSB/MSB bit ordering

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -297,6 +297,14 @@ List of characters to copy, belongs to previously declared "--font". Examples:
       'shown in the comment at the top of each generated font file. This is for friendliness with version-control.'
   });
 
+  parser.add_argument('--pixel-order', {
+    dest: 'pixel_order',
+    choices: [ 'MSB', 'LSB' ],
+    default: 'MSB',
+    help: 'Pixel bit ordering within bytes: MSB (default) or LSB.\n' +
+          'Note: LSB is incompatible with compression (requires --no-compress).'
+  });
+
   //
   // Process CLI options
   //
@@ -360,6 +368,11 @@ List of characters to copy, belongs to previously declared "--font". Examples:
     if (args.bpp === 3) {
       parser.error('--stride requires --bpp 1, 2, 4, or 8');
     }
+  }
+
+  // LSB pixel order is incompatible with compression
+  if (args.pixel_order === 'LSB' && args.no_compress === false) {
+    parser.error('--pixel-order LSB requires --no-compress');
   }
 
   //

--- a/lib/font/table_glyf.js
+++ b/lib/font/table_glyf.js
@@ -2,6 +2,7 @@
 
 const { BitStream } = require('bit-buffer');
 const debug = require('debug')('font.table.glyf');
+const { reorderByte } = require('../pixel_order');
 
 const u = require('../utils');
 const compress = require('./compress');
@@ -96,6 +97,13 @@ class Glyf {
     if (pixels.length === 0) return;
 
     const bpp = this.font.opts.bpp;
+    const pixelOrder = this.font.opts.pixel_order || 'MSB';
+
+    // Record start bit position for LSB byte reordering.
+    // Pixel data may start mid-byte (after glyph header bits in binary format),
+    // so we must track the exact bit offset to avoid corrupting header bits.
+    const startBitIndex = bitStream._index;
+
     let bit_pad_line = 0;
     if (this.font.opts.stride > 0) {
       const bit_count = pixels[0].length * bpp;
@@ -110,6 +118,22 @@ class Glyf {
       }
       if (bit_pad_line) {
         this.addPadding(bitStream, bit_pad_line / bpp);
+      }
+    }
+
+    // Apply LSB byte reordering if needed (MSB is default, no reordering needed)
+    if (pixelOrder === 'LSB') {
+      const endBitIndex = bitStream._index;
+      const buf = bitStream.view.buffer;
+
+      // Only reorder bytes that are fully occupied by pixel data.
+      // If pixel data starts mid-byte (e.g., after a non-byte-aligned glyph header),
+      // skip the shared first byte to avoid corrupting header bits.
+      const firstFullByte = Math.ceil(startBitIndex / 8);
+      const lastFullByte = Math.floor(endBitIndex / 8);
+
+      for (let i = firstFullByte; i < lastFullByte; i++) {
+        buf[i] = reorderByte(buf[i], bpp, 'LSB');
       }
     }
   }

--- a/lib/pixel_order.js
+++ b/lib/pixel_order.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/**
+ * PixelOrder module - pixel bit ordering within bytes
+ *
+ * Provides MSB/LSB pixel reordering to control the bit arrangement
+ * of pixels within each byte. Supports 1, 2, 4, 8 BPP configurations.
+ */
+
+const VALID_ORDERS = [ 'MSB', 'LSB' ];
+const VALID_BPP = [ 1, 2, 4, 8 ];
+
+/**
+ * Validate pixel order parameter
+ * @param {string} order - pixel order string
+ * @returns {boolean} whether the order is valid
+ */
+function validateOrder(order) {
+  return VALID_ORDERS.includes(order);
+}
+
+/**
+ * Validate BPP parameter
+ * @param {number} bpp - bits per pixel
+ * @returns {boolean} whether the bpp is valid
+ */
+function validateBpp(bpp) {
+  return VALID_BPP.includes(bpp);
+}
+
+/**
+ * Reorder pixel bits within a single byte (byte-level post-processing)
+ *
+ * MSB mode: most significant bit represents the leftmost pixel (default, returned as-is)
+ * LSB mode: least significant bit represents the leftmost pixel (requires bit reordering)
+ *
+ * @param {number} byte - input byte (0-255)
+ * @param {number} bpp - bits per pixel (1, 2, 4, 8)
+ * @param {string} order - 'MSB' or 'LSB'
+ * @returns {number} reordered byte
+ */
+function reorderByte(byte, bpp, order) {
+  if (!validateOrder(order)) {
+    throw new Error(`Invalid pixel order: ${order}. Valid options: ${VALID_ORDERS.join(', ')}`);
+  }
+  if (!validateBpp(bpp)) {
+    throw new Error(`Invalid BPP: ${bpp}. Valid options: ${VALID_BPP.join(', ')}`);
+  }
+
+  // MSB is the default behavior, no reordering needed
+  if (order === 'MSB') {
+    return byte & 0xFF;
+  }
+
+  // 8 BPP has only one pixel per byte, no reordering needed
+  if (bpp === 8) {
+    return byte & 0xFF;
+  }
+
+  // LSB mode: reverse the pixel order within the byte
+  const pixelsPerByte = 8 / bpp;
+  const mask = (1 << bpp) - 1;
+  let result = 0;
+
+  for (let i = 0; i < pixelsPerByte; i++) {
+    // Extract pixel from original byte (high bits to low bits)
+    const shift = (pixelsPerByte - 1 - i) * bpp;
+    const pixel = (byte >> shift) & mask;
+
+    // Place pixel at the reversed position (low bits to high bits)
+    result |= pixel << (i * bpp);
+  }
+
+  return result;
+}
+
+/**
+ * Reorder pixel bit ordering for an array of bytes
+ * @param {Array<number>} bytes - byte array
+ * @param {number} bpp - bits per pixel (1, 2, 4, 8)
+ * @param {string} order - 'MSB' or 'LSB'
+ * @returns {Array<number>} reordered byte array
+ */
+function reorderBytes(bytes, bpp, order) {
+  if (!Array.isArray(bytes)) {
+    throw new Error('bytes must be an array');
+  }
+  return bytes.map(b => reorderByte(b, bpp, order));
+}
+
+module.exports = {
+  validateOrder,
+  validateBpp,
+  reorderByte,
+  reorderBytes,
+  VALID_ORDERS,
+  VALID_BPP
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "browserify": "^17.0.0",
         "buffer": "^6.0.3",
         "eslint": "^8.7.0",
+        "fast-check": "^4.4.0",
         "file-saver": "^2.0.2",
         "mocha": "^9.1.4",
         "nyc": "^15.1.0",
@@ -936,7 +937,6 @@
       "integrity": "sha512-a0CgrW5A5kwuSu5J1RFRoMQaMs9yagvfH2jJMYVw56+/7NRI4KOtu612SG9Y1ERWfY55ZwzyFxtLWvD6LO+Anw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
         "@parcel/cache": "2.16.4",
@@ -2832,7 +2832,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3391,7 +3390,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4338,7 +4336,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4618,6 +4615,29 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.4.0.tgz",
+      "integrity": "sha512-s87BFAp8YaWYOBXjbTxeotaOhmA4hPYAyk9gBTFxdab25P6eAlqrryUvVMA2qd9bT/0Xq+YNJGtoVhJd/BxI4g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -7460,7 +7480,6 @@
       "integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "posthtml-parser": "^0.11.0",
         "posthtml-render": "^3.0.0"
@@ -7628,6 +7647,23 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "browserify": "^17.0.0",
     "buffer": "^6.0.3",
     "eslint": "^8.7.0",
+    "fast-check": "^4.4.0",
     "file-saver": "^2.0.2",
     "mocha": "^9.1.4",
     "nyc": "^15.1.0",

--- a/test/test_cli.js
+++ b/test/test_cli.js
@@ -5,6 +5,7 @@ const { execFileSync }  = require('child_process');
 const fs                = require('fs');
 const path              = require('path');
 const rimraf            = require('rimraf');
+const fc                = require('fast-check');
 const run               = require('../lib/cli').run;
 const range             = require('../lib/cli')._range;
 
@@ -133,6 +134,117 @@ describe('Cli', function () {
       assert.throws(
         () => range('1114444'),
         /out of unicode/
+      );
+    });
+  });
+
+  describe('pixel-order', function () {
+    /**
+     * Property 10: LSB and compression are mutually exclusive.
+     * Any configuration specifying both LSB pixel ordering and compression
+     * should produce an error.
+     */
+    it('Property 10: LSB with compression should error', async function () {
+      // Test that LSB + compression (default, no --no-compress) always fails
+      await assert.rejects(
+        run([
+          '--font', font, '--range', '0x41', '--size', '18',
+          '--bpp', '2', '--format', 'bin', '--pixel-order', 'LSB',
+          '-o', 'test_output.bin'
+        ], true),
+        /LSB requires --no-compress/
+      );
+    });
+
+    it('Property 10: LSB with compression - property test', async function () {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.constantFrom(1, 2, 4, 8),  // valid BPP values
+          fc.constantFrom('bin', 'lvgl', 'dump'),  // valid formats
+          async (bpp, format) => {
+            // LSB without --no-compress should always fail
+            try {
+              await run([
+                '--font', font, '--range', '0x41', '--size', '18',
+                '--bpp', String(bpp), '--format', format, '--pixel-order', 'LSB',
+                '-o', 'test_output_prop'
+              ], true);
+              // If we get here without error, the test should fail
+              assert.fail('Expected error for LSB without --no-compress');
+            } catch (err) {
+              // Should contain error about LSB incompatibility
+              assert.ok(
+                /LSB requires --no-compress/.test(err.message),
+                `Expected LSB incompatibility error, got: ${err.message}`
+              );
+            }
+          }
+        ),
+        { numRuns: 12 }  // 4 BPP * 3 formats = 12 combinations
+      );
+    });
+
+    it('Should accept LSB with --no-compress', async function () {
+      let rnd = Math.random().toString(16).slice(2, 10) + '.font';
+      let file = path.join(__dirname, rnd);
+
+      try {
+        await run([
+          '--font', font, '--range', '0x41', '--size', '18',
+          '-o', file, '--bpp', '2', '--format', 'bin',
+          '--pixel-order', 'LSB', '--no-compress'
+        ], true);
+
+        // Should succeed and create file
+        assert.ok(fs.existsSync(file));
+      } finally {
+        if (fs.existsSync(file)) fs.unlinkSync(file);
+      }
+    });
+
+    it('Should accept MSB with compression (default)', async function () {
+      let rnd = Math.random().toString(16).slice(2, 10) + '.font';
+      let file = path.join(__dirname, rnd);
+
+      try {
+        await run([
+          '--font', font, '--range', '0x41', '--size', '18',
+          '-o', file, '--bpp', '2', '--format', 'bin',
+          '--pixel-order', 'MSB'
+        ], true);
+
+        // Should succeed and create file
+        assert.ok(fs.existsSync(file));
+      } finally {
+        if (fs.existsSync(file)) fs.unlinkSync(file);
+      }
+    });
+
+    it('Should default to MSB when --pixel-order not specified', async function () {
+      let rnd = Math.random().toString(16).slice(2, 10) + '.font';
+      let file = path.join(__dirname, rnd);
+
+      try {
+        await run([
+          '--font', font, '--range', '0x41', '--size', '18',
+          '-o', file, '--bpp', '2', '--format', 'bin'
+        ], true);
+
+        // Should succeed (MSB is default, compatible with compression)
+        assert.ok(fs.existsSync(file));
+      } finally {
+        if (fs.existsSync(file)) fs.unlinkSync(file);
+      }
+    });
+
+    it('Should reject invalid pixel-order value', async function () {
+      await assert.rejects(
+        run([
+          '--font', font, '--range', '0x41', '--size', '18',
+          '--bpp', '2', '--format', 'bin', '--pixel-order', 'INVALID',
+          '-o', 'test_output.bin'
+        ], true),
+        /invalid choice.*INVALID/i
       );
     });
   });

--- a/test/test_pixel_order.js
+++ b/test/test_pixel_order.js
@@ -1,0 +1,356 @@
+'use strict';
+
+const assert = require('assert');
+const fc = require('fast-check');
+const { reorderByte, validateOrder, validateBpp, VALID_BPP } = require('../lib/pixel_order');
+const Font = require('../lib/font/font');
+
+describe('PixelOrder', function () {
+
+  describe('validateOrder', function () {
+    it('Should accept MSB', function () {
+      assert.strictEqual(validateOrder('MSB'), true);
+    });
+
+    it('Should accept LSB', function () {
+      assert.strictEqual(validateOrder('LSB'), true);
+    });
+
+    it('Should reject invalid order', function () {
+      assert.strictEqual(validateOrder('invalid'), false);
+      assert.strictEqual(validateOrder(''), false);
+      assert.strictEqual(validateOrder(null), false);
+    });
+  });
+
+  describe('validateBpp', function () {
+    it('Should accept valid BPP values', function () {
+      assert.strictEqual(validateBpp(1), true);
+      assert.strictEqual(validateBpp(2), true);
+      assert.strictEqual(validateBpp(4), true);
+      assert.strictEqual(validateBpp(8), true);
+    });
+
+    it('Should reject invalid BPP values', function () {
+      assert.strictEqual(validateBpp(0), false);
+      assert.strictEqual(validateBpp(3), false);
+      assert.strictEqual(validateBpp(5), false);
+      assert.strictEqual(validateBpp(16), false);
+    });
+  });
+
+  describe('reorderByte', function () {
+    /**
+     * Property 1: MSB pixel ordering correctness
+     * For any pixel data and supported BPP, when MSB ordering is specified,
+     * the most significant bit should represent the leftmost pixel.
+     */
+    it('Property 1: MSB pixel ordering - highest bit represents leftmost pixel', function () {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 0, max: 255 }),
+          fc.constantFrom(...VALID_BPP),
+          (byte, bpp) => {
+            const result = reorderByte(byte, bpp, 'MSB');
+
+            // In MSB mode, input should equal output (default behavior)
+            assert.strictEqual(result, byte & 0xFF);
+
+            // Verify the most significant bit represents the leftmost pixel
+            const pixelsPerByte = 8 / bpp;
+            const mask = (1 << bpp) - 1;
+            const firstPixelShift = (pixelsPerByte - 1) * bpp;
+            const firstPixel = (byte >> firstPixelShift) & mask;
+
+            // The first pixel in the result should also be at the highest bits
+            const resultFirstPixel = (result >> firstPixelShift) & mask;
+            assert.strictEqual(resultFirstPixel, firstPixel);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    /**
+     * Property 2: LSB pixel ordering correctness
+     * For any pixel data and supported BPP, when LSB ordering is specified,
+     * the least significant bit should represent the leftmost pixel.
+     */
+    it('Property 2: LSB pixel ordering - lowest bit represents leftmost pixel', function () {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 0, max: 255 }),
+          fc.constantFrom(1, 2, 4), // Exclude 8 BPP since it needs no reordering
+          (byte, bpp) => {
+            const result = reorderByte(byte, bpp, 'LSB');
+
+            // Verify the least significant bit represents the leftmost pixel
+            const pixelsPerByte = 8 / bpp;
+            const mask = (1 << bpp) - 1;
+
+            // Extract the first pixel from the original byte (at highest bits)
+            const firstPixelShift = (pixelsPerByte - 1) * bpp;
+            const firstPixel = (byte >> firstPixelShift) & mask;
+
+            // In LSB mode, the first pixel should be at the lowest bits
+            const resultFirstPixel = result & mask;
+            assert.strictEqual(resultFirstPixel, firstPixel);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    describe('1 BPP specific cases', function () {
+      it('Should reverse pixel order for LSB', function () {
+        // 1 BPP: 8 pixels per byte
+        // MSB: bit7=p0, bit6=p1, ..., bit0=p7
+        // LSB: bit0=p0, bit1=p1, ..., bit7=p7
+        assert.strictEqual(reorderByte(0b10000000, 1, 'LSB'), 0b00000001);
+        assert.strictEqual(reorderByte(0b11110000, 1, 'LSB'), 0b00001111);
+        assert.strictEqual(reorderByte(0b10101010, 1, 'LSB'), 0b01010101);
+      });
+
+      it('Should keep MSB unchanged', function () {
+        assert.strictEqual(reorderByte(0b10000000, 1, 'MSB'), 0b10000000);
+        assert.strictEqual(reorderByte(0b11110000, 1, 'MSB'), 0b11110000);
+      });
+    });
+
+    describe('2 BPP specific cases', function () {
+      it('Should reverse pixel order for LSB', function () {
+        // 2 BPP: 4 pixels per byte
+        // MSB: [p0:bits7-6][p1:bits5-4][p2:bits3-2][p3:bits1-0]
+        // LSB: [p3:bits7-6][p2:bits5-4][p1:bits3-2][p0:bits1-0]
+        assert.strictEqual(reorderByte(0b11000000, 2, 'LSB'), 0b00000011);
+        assert.strictEqual(reorderByte(0b11100100, 2, 'LSB'), 0b00011011);
+      });
+    });
+
+    describe('4 BPP specific cases', function () {
+      it('Should reverse pixel order for LSB', function () {
+        // 4 BPP: 2 pixels per byte
+        // MSB: [p0:bits7-4][p1:bits3-0]
+        // LSB: [p1:bits7-4][p0:bits3-0]
+        assert.strictEqual(reorderByte(0xF0, 4, 'LSB'), 0x0F);
+        assert.strictEqual(reorderByte(0xAB, 4, 'LSB'), 0xBA);
+      });
+    });
+
+    describe('8 BPP specific cases', function () {
+      it('Should not change byte for 8 BPP (single pixel per byte)', function () {
+        assert.strictEqual(reorderByte(0xFF, 8, 'LSB'), 0xFF);
+        assert.strictEqual(reorderByte(0x42, 8, 'LSB'), 0x42);
+        assert.strictEqual(reorderByte(0x00, 8, 'MSB'), 0x00);
+      });
+    });
+  });
+});
+
+
+describe('BPP Packing Properties', function () {
+
+  /**
+   * Property 12: 1 BPP packing correctness
+   * For any 1 BPP pixel data, 8 pixels per byte should be packed
+   * with the specified bit ordering.
+   */
+  it('Property 12: 1 BPP packing - 8 pixels per byte with correct bit order', function () {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 255 }),
+        fc.constantFrom('MSB', 'LSB'),
+        (byte, order) => {
+          const result = reorderByte(byte, 1, order);
+
+          // Result should still be a valid byte
+          assert.ok(result >= 0 && result <= 255);
+
+          // Verify 8 pixels are correctly packed (each pixel is 1 bit)
+          let pixelCount = 0;
+          for (let i = 0; i < 8; i++) {
+            const pixel = (result >> i) & 1;
+            assert.ok(pixel === 0 || pixel === 1);
+            pixelCount++;
+          }
+          assert.strictEqual(pixelCount, 8);
+
+          // Verify bit ordering: MSB has first pixel at bit7, LSB at bit0
+          const firstPixelInInput = (byte >> 7) & 1;
+          if (order === 'MSB') {
+            assert.strictEqual((result >> 7) & 1, firstPixelInInput);
+          } else {
+            assert.strictEqual(result & 1, firstPixelInInput);
+          }
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  /**
+   * Property 13: 2 BPP packing correctness
+   * For any 2 BPP pixel data, 4 pixels per byte should be packed
+   * with the specified bit ordering.
+   */
+  it('Property 13: 2 BPP packing - 4 pixels per byte with correct bit order', function () {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 255 }),
+        fc.constantFrom('MSB', 'LSB'),
+        (byte, order) => {
+          const result = reorderByte(byte, 2, order);
+
+          assert.ok(result >= 0 && result <= 255);
+
+          // Verify 4 pixels are correctly packed (each pixel is 2 bits)
+          const pixels = [];
+          for (let i = 0; i < 4; i++) {
+            const pixel = (result >> (i * 2)) & 0x03;
+            assert.ok(pixel >= 0 && pixel <= 3);
+            pixels.push(pixel);
+          }
+          assert.strictEqual(pixels.length, 4);
+
+          // Verify bit ordering
+          const firstPixelInInput = (byte >> 6) & 0x03;
+          if (order === 'MSB') {
+            assert.strictEqual((result >> 6) & 0x03, firstPixelInInput);
+          } else {
+            assert.strictEqual(result & 0x03, firstPixelInInput);
+          }
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  /**
+   * Property 14: 4 BPP packing correctness
+   * For any 4 BPP pixel data, 2 pixels per byte should be packed
+   * with the specified bit ordering.
+   */
+  it('Property 14: 4 BPP packing - 2 pixels per byte with correct bit order', function () {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 255 }),
+        fc.constantFrom('MSB', 'LSB'),
+        (byte, order) => {
+          const result = reorderByte(byte, 4, order);
+
+          assert.ok(result >= 0 && result <= 255);
+
+          // Verify 2 pixels are correctly packed (each pixel is 4 bits)
+          const pixel0 = result & 0x0F;
+          const pixel1 = (result >> 4) & 0x0F;
+          assert.ok(pixel0 >= 0 && pixel0 <= 15);
+          assert.ok(pixel1 >= 0 && pixel1 <= 15);
+
+          // Verify bit ordering
+          const firstPixelInInput = (byte >> 4) & 0x0F;
+          if (order === 'MSB') {
+            assert.strictEqual((result >> 4) & 0x0F, firstPixelInInput);
+          } else {
+            assert.strictEqual(result & 0x0F, firstPixelInInput);
+          }
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  /**
+   * Property 15: 8 BPP no reordering
+   * For any 8 BPP pixel data, each byte holds a single pixel,
+   * so no bit reordering is needed regardless of the order setting.
+   */
+  it('Property 15: 8 BPP no reordering - 1 pixel per byte unchanged', function () {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 255 }),
+        fc.constantFrom('MSB', 'LSB'),
+        (byte, order) => {
+          const result = reorderByte(byte, 8, order);
+
+          // For 8 BPP, result should always equal input regardless of order
+          assert.strictEqual(result, byte);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});
+
+
+describe('Default Behavior Properties', function () {
+
+  // Minimal test font data
+  function createTestFontData() {
+    return {
+      size: 10,
+      ascent: 8,
+      descent: -2,
+      typoAscent: 8,
+      typoDescent: -2,
+      typoLineGap: 0,
+      glyphs: [
+        {
+          code: 65, // 'A'
+          advanceWidth: 7,
+          bbox: { x: 0, y: 0, width: 6, height: 8 },
+          kerning: {},
+          pixels: [
+            [ 0, 128, 128, 128, 128, 0 ],
+            [ 128, 128, 0, 0, 128, 128 ],
+            [ 128, 128, 0, 0, 128, 128 ],
+            [ 255, 255, 255, 255, 255, 255 ],
+            [ 128, 128, 0, 0, 128, 128 ],
+            [ 128, 128, 0, 0, 128, 128 ],
+            [ 128, 128, 0, 0, 128, 128 ],
+            [ 0, 0, 0, 0, 0, 0 ]
+          ]
+        }
+      ]
+    };
+  }
+
+  /**
+   * Property 3: Default ordering behavior
+   * When pixel_order is not specified, the result should be identical
+   * to explicitly specifying MSB ordering.
+   */
+  it('Property 3: Default ordering behavior - undefined equals MSB', function () {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(1, 2, 4, 8),
+        bpp => {
+          const fontData = createTestFontData();
+
+          // Create font with explicit MSB
+          const fontMSB = new Font(fontData, {
+            bpp,
+            no_compress: true,
+            pixel_order: 'MSB'
+          });
+
+          // Create font with undefined pixel_order (default behavior)
+          const fontDefault = new Font(fontData, {
+            bpp,
+            no_compress: true
+          });
+
+          // Get glyf table binary data
+          const binMSB = fontMSB.glyf.toBin();
+          const binDefault = fontDefault.glyf.toBin();
+
+          // The binary output should be identical
+          assert.strictEqual(binMSB.length, binDefault.length,
+            `Glyf table length mismatch for BPP ${bpp}`);
+          assert.ok(binMSB.equals(binDefault),
+            `Glyf table content mismatch for BPP ${bpp}: default should equal MSB`);
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Add a `--pixel-order` CLI option to control pixel bit arrangement within each byte of glyph bitmap data. Defaults to `MSB` (current behavior), with `LSB` as a new option.

## Motivation

Some embedded LCD controllers (e.g., SSD1306 in page-addressing mode, certain SPI-driven monochrome displays) expect pixel data in LSB-first bit ordering. Currently, users must post-process the font output to reverse bit order per byte, which is error-prone and adds complexity to the build pipeline.

This option enables direct compatibility without post-processing.

## Changes

| File | Description |
|------|-------------|
| `lib/pixel_order.js` | New module: byte-level pixel bit reordering for 1/2/4/8 BPP |
| `lib/font/table_glyf.js` | Integrate LSB reordering into `storePixelsRaw()` |
| `lib/cli.js` | Add `--pixel-order {MSB,LSB}` argument with validation |
| `test/test_pixel_order.js` | Property-based tests (fast-check) + specific cases for all BPP |
| `test/test_cli.js` | CLI integration tests for the new option |
| `package.json` | Add `fast-check` to devDependencies (property-based testing) |

## Design decisions

- **Byte-level post-processing**: Reordering is applied after pixel packing, keeping the core `BitStream` logic untouched. This minimizes risk to existing functionality.
- **LSB + compression mutual exclusion**: RLE compression operates on MSB-ordered data. Allowing LSB with compression would produce incorrect output, so the CLI validates and rejects this combination.
- **8 BPP passthrough**: At 8 bits per pixel, each byte holds exactly one pixel — no reordering is needed regardless of the setting.
- **Default MSB**: Fully backward compatible. Existing users see no change.

## Usage

```bash
# LSB ordering (requires --no-compress)
lv_font_conv --font my_font.ttf -r 0x20-0x7F --size 16 --bpp 1 \
  --format bin --no-compress --pixel-order LSB -o my_font.bin

# MSB ordering (default, same as before)
lv_font_conv --font my_font.ttf -r 0x20-0x7F --size 16 --bpp 1 \
  --format bin -o my_font.bin
```

## Testing

- Property-based tests using `fast-check` covering all BPP × order combinations
- Specific bit-pattern tests for each BPP (1, 2, 4, 8)
- CLI integration tests: LSB+compress rejection, LSB+no-compress acceptance, MSB default behavior, invalid value rejection
- All existing tests continue to pass

## Notes

`package-lock.json` has minor `"peer": true` field removals due to npm version differences. The only actual dependency additions are `fast-check` and its dependency `pure-rand`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `--pixel-order` CLI option to control per-byte pixel bit order in glyph bitmaps. Default stays `MSB`; `LSB` is available for devices that read LSB-first.

- **New Features**
  - Add `--pixel-order {MSB,LSB}` to choose pixel bit ordering when packing glyphs.
  - Byte-level reordering happens after packing and only on full pixel bytes to avoid touching glyph headers; supports 1/2/4/8 BPP (8 BPP is a no-op).
  - CLI prevents `--pixel-order LSB` with compression; use with `--no-compress`.

- **Migration**
  - For LSB-first displays (e.g., SSD1306), run with `--pixel-order LSB --no-compress`.

<sup>Written for commit c0a47c67eddf1e15fdeaccfe0d56263fe6cae0d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

