### PR TITLE
Add support for tabular numbers (equal widths for 0-9)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -251,6 +251,13 @@ List of characters to copy, belongs to previously declared "--font". Examples:
     help: 'Drop kerning info to reduce size (not recommended).'
   });
 
+  parser.add_argument('--tabular-nums', {
+    dest: 'tabular_nums',
+    action: 'store_true',
+    default: false,
+    help: 'Force ASCII digits 0-9 to use equal advance width.'
+  });
+
   parser.add_argument('--byte-align', {
     dest: 'byte_align',
     action: 'store_true',

--- a/lib/collect_font_data.js
+++ b/lib/collect_font_data.js
@@ -123,8 +123,29 @@ module.exports = async function collect_font_data(args) {
     });
   }
 
+  if (args.tabular_nums) {
+    const digits = glyphs.filter(g => g.code >= 0x30 && g.code <= 0x39);
+    if (digits.length === 10) {
+      // Determine the widest advance width in this font
+      const targetAdvance = Math.max(...digits.map(g => g.advanceWidth));
+
+      for (const g of digits) {
+        const diff = targetAdvance - g.advanceWidth;
+
+        if (diff > 0) {
+          g.bbox.x += Math.round(diff / 2);
+          g.advanceWidth = targetAdvance;
+        }
+      }
+    }
+  }
+
   if (!args.no_kerning) {
     let existing_dst_charcodes = glyphs.map(g => g.code);
+    if (args.tabular_nums) {
+      // Kerning values for digits are not merged because they would be incorrect after making them tabular.
+      existing_dst_charcodes = existing_dst_charcodes.filter(c => c < 0x30 || c > 0x39);
+    }
 
     for (let { code, kerning } of glyphs) {
       let src_code = mapping[code].code;


### PR DESCRIPTION
Add optional support for tabular (monospaced) digits to improve numeric alignment in UI use cases such as clocks, counters, and tables.

### Summary

This PR introduces a new CLI flag `--tabular-nums` that forces ASCII digits (`0–9`) to use a uniform advance width. When enabled, all digit glyphs are adjusted to match the widest digit in the font, ensuring consistent horizontal spacing.

### Details

* **New CLI option**

  * `--tabular-nums`: when enabled, modifies digits `0x30–0x39` to have equal advance width.

* **Glyph processing**

  * Detects all digit glyphs (`0–9`).
  * Computes the maximum `advanceWidth` among them.
  * Expands narrower digits to match this width.
  * Adjusts `bbox.x` to keep glyphs visually centered after width normalization.

* **Kerning handling**

  * Kerning for digits is excluded when `--tabular-nums` is active.
  * Rationale: existing kerning pairs would become invalid after width normalization and could produce incorrect spacing.

### Motivation

Many embedded UI scenarios (e.g., LVGL dashboards, timers, numeric readouts) benefit from tabular digits to avoid layout shifts when values change. This option provides a simple way to enforce consistent digit spacing without requiring a separate font.

### Backward compatibility

* Disabled by default.
* No impact on existing behavior unless `--tabular-nums` is explicitly specified.

### Notes

* Only applies when all 10 ASCII digits are present in the glyph set.
* Does not modify non-digit glyphs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional support for tabular (monospaced) digits to keep numbers aligned in UIs like clocks, counters, and tables. A new CLI flag, `--tabular-nums`, makes digits `0–9` use equal advance width.

- **New Features**
  - `--tabular-nums`: sets ASCII digits (0x30–0x39) to the widest digit width and centers narrower digits.
  - Digit kerning is skipped when enabled to prevent invalid spacing.
  - Disabled by default; applies only if all 10 digits are present.

<sup>Written for commit b0869051c2fd0ecc424cd2f5118183b62107eb90. Summary will update on new commits. <a href="https://cubic.dev/pr/lvgl/lv_font_conv/pull/154?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

